### PR TITLE
fix: fixing infinite loop condtion when there is astrix but there is no slash following it

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -263,6 +263,7 @@ func (s *Scanner) consumeMultilineComment() {
 				s.current += 2
 				return
 			}
+			s.advance()
 
 		default:
 			s.advance()


### PR DESCRIPTION
I was following your series, which is very awesome.  And I was trying to implement the challenge on my own, and after a while, my solution was not good at all, and after taking your solution, I found in my test case that led to an infinite loop, for example, this code. 
`
/*   lexer
lexing *
lex
`
As it has an asterisk but is not followed by a slash.